### PR TITLE
fix: #issue 1 fix windows eslint

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,2 @@
+# Ensuring github workflows eol for all platform is lf
+* eol=lf

--- a/package.json
+++ b/package.json
@@ -14,8 +14,8 @@
     "start": "tsdx watch",
     "build": "tsdx build && node ./scripts/flowgen.js",
     "test": "tsdx test",
-    "lint": "eslint '--ext' '.js,.ts' './src' './test'",
-    "lint-fix": "eslint '--ext' '.js,.ts' './src' './test' --fix",
+    "lint": "eslint ./src ./test --ext .js,.ts",
+    "lint-fix": "eslint ./src ./test --ext .js,.ts --fix",
     "prepare": "tsdx build",
     "size": "size-limit",
     "analyze": "size-limit --why"


### PR DESCRIPTION
This issue was caused by 2 problems:
1. unrecognised command pattern `eslint '--ext' '.js,.ts' './src' './test'`
    solution: change to `eslint ./src ./test --ext .js,.ts`  
2. windows platform changed eol to crlf:
    solution: add `* eol=lf` to `.gitattributes`